### PR TITLE
Fix link position when header has attributes

### DIFF
--- a/include/class-add-anchor-links.php
+++ b/include/class-add-anchor-links.php
@@ -2,7 +2,7 @@
 
 // If this file is called directly, abort.
 if ( ! defined( 'WPINC' ) ) {
-	die;
+    die;
 }
 
 if ( ! class_exists( 'Add_Anchor_Links' ) ) {
@@ -36,23 +36,25 @@ if ( ! class_exists( 'Add_Anchor_Links' ) ) {
 
             // search for headlines
             $pattern = '#<h([1-6])(?: [^>]+)?>(.+?)</h\1>#is';
-            preg_match_all( $pattern , $text , $headlines, PREG_SET_ORDER);            
+            preg_match_all( $pattern , $text , $headlines, PREG_OFFSET_CAPTURE );
+
+            $offset = 0;
 
             if( $headlines ){
-				foreach ($headlines as $headline) {
+                foreach ($headlines[2] as $match) {
+                    list($headline, $pos) = $match;
 
-                    if ( strlen( $headline[2] ) ) {
+                    if ( strlen( $headline ) ) {
 
-                        $anchor = sanitize_title( $headline[2] );
+                        $anchor = sanitize_title( $headline );
                         $icon = '<a href="#'.$anchor.'" aria-hidden="true" class="aal_anchor" id="'.$anchor.'"><svg aria-hidden="true" class="aal_svg" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg></a>';
 
-                        $pos = strpos($text, $headline[0]) + 4; 
-					    $text = substr_replace($text, $icon, $pos, 0); // inssert after h tag
-
+                        $text    = substr_replace($text, $icon, $offset + $pos, 0); // insert after h tag
+                        $offset += strlen($icon);
                     }
 
-				}
-			}
+                }
+            }
 
             
             return $text;


### PR DESCRIPTION
The anchor isn't inserted at the right position if the header has attributes:

``` html
<h2 data-example="value">My title</h2>
```

becomes

``` html
<h2 <a href="#my-title" aria-hidden="true" class="aal_anchor" id="my-title"><svg aria-hidden="true" class="aal_svg" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg></a>data-example="value">My title</h2>
```