### PR TITLE
Prevent duplicate id in heading and inserted a tag

### DIFF
--- a/include/class-add-anchor-links.php
+++ b/include/class-add-anchor-links.php
@@ -59,7 +59,7 @@ if (! class_exists('AddAnchorLinks')) {
 		{
 
 			// Search for headlines.
-			$pattern = '#<h([1-6]).*?(?:id=["\'](.*?)["\']).*?>(.+?)</h\1>#is';
+			$pattern = '#<h([1-6]).*?(?:id=["\'](.*?)["\'])?.*?>(.+?)</h\1>#is';
 
 			preg_match_all($pattern, $text, $headlines, PREG_OFFSET_CAPTURE);
 

--- a/include/class-add-anchor-links.php
+++ b/include/class-add-anchor-links.php
@@ -59,18 +59,24 @@ if (! class_exists('AddAnchorLinks')) {
 		{
 
 			// Search for headlines.
-			$pattern = '#<h([1-6])(?: [^>]+)?>(.+?)</h\1>#is';
+			$pattern = '#<h([1-6]).*?(?:id=["\'](.*?)["\']).*?>(.+?)</h\1>#is';
+
 			preg_match_all($pattern, $text, $headlines, PREG_OFFSET_CAPTURE);
 
 			$offset = 0;
 
 			if ($headlines) {
-				foreach ($headlines[2] as $match) {
-					list($headline, $pos) = $match;
+				for ($i=0; $i<$headlines[3].length; $i++) {
+
+					list($headline, $pos) = $headlines[3][$i];
 
 					if (strlen($headline)) {
 						$anchor = \sanitize_title($headline);
-						$icon = '<a href="#' . $anchor . '" aria-hidden="true" class="aal_anchor" id="' . $anchor . '"><svg aria-hidden="true" class="aal_svg" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg></a>';
+						
+						// If this id is already used on the heading tag, don't use it again.
+						$id = !empty($headlines[2][$i][0]) && $headlines[2][i][0] === $anchor ? '' : ' id="'.$anchor.'"';
+
+						$icon = '<a href="#' . $anchor . '" aria-hidden="true" class="aal_anchor"'.$id.'><svg aria-hidden="true" class="aal_svg" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg></a>';
 
 						$text    = substr_replace($text, $icon, $offset + $pos, 0); // Insert after H tag.
 						$offset += strlen($icon);

--- a/include/class-add-anchor-links.php
+++ b/include/class-add-anchor-links.php
@@ -66,7 +66,7 @@ if (! class_exists('AddAnchorLinks')) {
 			$offset = 0;
 
 			if ($headlines) {
-				for ($i=0; $i<$headlines[3].length; $i++) {
+				for ($i=0; $i<count($headlines[3]); $i++) {
 
 					list($headline, $pos) = $headlines[3][$i];
 
@@ -74,7 +74,7 @@ if (! class_exists('AddAnchorLinks')) {
 						$anchor = \sanitize_title($headline);
 						
 						// If this id is already used on the heading tag, don't use it again.
-						$id = !empty($headlines[2][$i][0]) && $headlines[2][i][0] === $anchor ? '' : ' id="'.$anchor.'"';
+						$id = !empty($headlines[2][$i][0]) && $headlines[2][$i][0] === $anchor ? '' : ' id="'.$anchor.'"';
 
 						$icon = '<a href="#' . $anchor . '" aria-hidden="true" class="aal_anchor"'.$id.'><svg aria-hidden="true" class="aal_svg" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg></a>';
 


### PR DESCRIPTION
If the heading tag already has the exact same id as what will be inserted into the <a> tag, do not add the id to the <a> tag. This helps with plugins like SimpleTOC which adds an id to all of the heading tags.